### PR TITLE
develop to main

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -105,45 +105,87 @@ The numberformat can also be changed by calling the macro \lstinline|\renewcomma
 
 \section{Math}
 \subsection{Abs and Norm}
-\commandscmd{abs}{norm}\footnote{see \url{https://tex.stackexchange.com/a/43009}} produce the following:
-\begin{table}[h!t]
-  \centering
-  \begin{tabular}{ccc}
-    \toprule
-    \thead{command} & \thead{non-starred}       & \thead{starred}            \\
-    \midrule
-    \verb|\abs|     & \(\abs{\frac{1}{2}x^2}\)  & \(\abs*{\frac{1}{2}x^2}\)  \\
-    \verb|\norm|    & \(\norm{\frac{1}{2}x^2}\) & \(\norm*{\frac{1}{2}x^2}\) \\
-    \bottomrule
-  \end{tabular}
-\end{table}
+\commandcmd{abs} produces the following:
+\begin{itemize}
+  \item \emph{non-starred}
+        \[\abs{a}\]
+        \[\abs{\frac{a}{2}}\]
+  \item \emph{starred}
+        \[\abs*{a}\]
+        \[\abs*{\frac{a}{2}}\]
+\end{itemize}
 
-The difference between \emph{starred} and \emph{non-starred} lies in the scaling of the bars.
+\commandcmd{norm} produces the following:
+\begin{itemize}
+  \item \emph{non-starred}
+        \[\norm{a}\]
+        \[\norm{\frac{a}{2}}\]
+  \item \emph{starred}
+        \[\norm*{a}\]
+        \[\norm*{\frac{a}{2}}\]
+\end{itemize}
+
+\subsection{Ceil and Floor}
+\commandcmd{ceil} produces the following:
+\begin{itemize}
+  \item \emph{non-starred}
+        \[\ceil{a}\]
+        \[\ceil{\frac{a}{2}}\]
+  \item \emph{starred}
+        \[\ceil*{a}\]
+        \[\ceil*{\frac{a}{2}}\]
+\end{itemize}
+
+\commandcmd{floor} produces the following:
+\begin{itemize}
+  \item \emph{non-starred}
+        \[\floor{a}\]
+        \[\floor{\frac{a}{2}}\]
+  \item \emph{starred}
+        \[\floor*{a}\]
+        \[\floor*{\frac{a}{2}}\]
+\end{itemize}
 
 \subsection{Sets and Tupels}
 \commandcmd{mset} produces the following:
-\[\mset{1, 2, 3, 4}\]
-\[\mset{a \mid \frac{a}{2} > 5}\]
-\[\mset{}\]
-\[\mset{\mset{a}}\]
-
-\commandcmd{mset*} produces the following:
-\[\mset*{1, 2, 3, 4}\]
-\[\mset*{a \mid \frac{a}{2} > 5}\]
-\[\mset*{}\]
+\begin{itemize}
+  \item \emph{non-starred}:
+        \[\mset{1, 2, 3, 4}\]
+        \[\mset{a \mid \frac{a}{2} > 5}\]
+        \[\mset{}\]
+        \[\mset{\mset{a}}\]
+  \item \emph{starred}:
+        \[\mset*{1, 2, 3, 4}\]
+        \[\mset*{a \mid \frac{a}{2} > 5}\]
+        \[\mset*{}\]
+        \[\mset*{\mset*{a}}\]
+\end{itemize}
 
 \commandcmd{msetmid} produces the following:
-\[\msetmid{a}{\frac{a}{2} > 5}\]
-This command automatically places a scaling mid symbol.
-
-\commandcmd{msetmidsa} produces the following:
-\[\mset{\msetmidsa}\]
-This command has to be used inside of \lstinline{\mset} or \lstinline{\mset*}, and creates a \emph{standalone} scaling mid symbol. This allows for multiple mid symbols in one set e.g.: \(\mset{\msetmidsa \msetmidsa}\)
+\begin{itemize}
+  \item \emph{non-starred}:
+        \[\msetmid{x}{x > 0}\]
+        \[\msetmid{\frac{1}{x}}{x > 0}\]
+        \[\msetmid{}{}\]
+        \[\msetmid{x}{x \in \mset{a}}\]
+  \item \emph{starred}:
+        \[\msetmid*{x}{x > 0}\]
+        \[\msetmid*{\frac{1}{x}}{x > 0}\]
+        \[\msetmid*{}{}\]
+        \[\msetmid*{x}{x \in \mset{a}}\]
+\end{itemize}
 
 \commandcmd{mtupel} produces the following:
-\[\mtupel{1, 2, 3, 4}\]
-\[\mtupel{\frac{1}{2}, \frac{2}{3}}\]
-\[\mtupel{}\]
+\begin{itemize}
+  \item \emph{non-starred}:
+        \[\mtupel{1, 2, 3, 4}\]
+        \[\mtupel{\frac{1}{2}, \frac{2}{3}}\]
+        \[\mtupel{}\]
+  \item \emph{starred}:
+        \[\mtupel*{1, 2, 3, 4}\]
+        \[\mtupel*{\frac{1}{2}, \frac{2}{3}}\]
+        \[\mtupel*{}\]
+\end{itemize}
 
 \subsection{Other}
 
@@ -162,18 +204,18 @@ which can be used e.g. in the following context:
 \\
 Boltzmann distribution: state occupation probability of a thermodynamical system within fixed temperature \(T\): \[p(x) = \alpha \cdot e^{-\frac{E(x)}{k \cdot T}}\] where:
 \begin{conditions}
-  x       & \sep & state \\
-  \alpha  & \sep & degeneracy (= number of states \(x'\) with the same energy as \(x\)) \\
-  E(x)    & \sep & energy \\
-  k       & \sep & Bolzmann constant
+  x      & \sep & state                                                                \\
+  \alpha & \sep & degeneracy (= number of states \(x'\) with the same energy as \(x\)) \\
+  E(x)   & \sep & energy                                                               \\
+  k      & \sep & Bolzmann constant
 \end{conditions}
 It is possible to have different symbols instead of the dots:
 
 \begin{conditions}[=]
-  x       & \sep & state \\
-  \alpha  & \sep & degeneracy (= number of states \(x'\) with the same energy as \(x\)) \\
-  E(x)    & \sep & energy \\
-  k       & \sep & Bolzmann constant
+  x      & \sep & state                                                                \\
+  \alpha & \sep & degeneracy (= number of states \(x'\) with the same energy as \(x\)) \\
+  E(x)   & \sep & energy                                                               \\
+  k      & \sep & Bolzmann constant
 \end{conditions}
 
 \section{Logic}

--- a/example.tex
+++ b/example.tex
@@ -1,20 +1,22 @@
 \documentclass[10pt]{article}
 \usepackage{tuwienassignment}
 
-%%%
-%%% PLACE CUSTOM STYLES HERE
-%%%
 \usepackage{lipsum} % dummy text
 \newcommand{\environmentcmd}[1]{\par\noindent\textbf{Environment:} \lstinline{#1}}
 \newcommand{\commandcmd}[1]{\par\noindent\textbf{Command:} \lstinline{\\#1}}
 \newcommand{\commandscmd}[2]{\par\noindent\textbf{Commands:} \lstinline{\\#1} and \lstinline{\\#2}}
+
+%%%
+%%% PLACE CUSTOM STYLES HERE
+%%%
+
+\selectlanguage{english}
 
 \title{Title}
 \author{Author}
 \matrikelnr{12345678}
 
 \begin{document}
-\selectlanguage{english}
 \maketitle
 
 \section{Introduction}

--- a/example.tex
+++ b/example.tex
@@ -189,15 +189,15 @@ The numberformat can also be changed by calling the macro \lstinline|\renewcomma
 
 \subsection{Other}
 
-\commandcmd{mappliesto} produces the following with spacing:
-\[\mappliesto\]
+\commandcmd{appliesto} produces the following with spacing:
+\[\appliesto\]
 which can be used e.g. in the following context:
-\[\mathbf{n}(u) = \frac{\sum_{i = 0}^n w_i \mathbf{d}_i N_i^k(u)}{\sum_{i = 0}^n w_i N_i^k(u)} \mappliesto u \in \left[u_0, u_{n + l}\right) \subset \mathbb{R}\]
+\[\mathbf{n}(u) = \frac{\sum_{i = 0}^n w_i \mathbf{d}_i N_i^k(u)}{\sum_{i = 0}^n w_i N_i^k(u)} \appliesto u \in \left[u_0, u_{n + l}\right) \subset \mathbb{R}\]
 
-\commandcmd{mdefinedas} produces the following:
-\[\mdefinedas\]
+\commandcmd{definedas} produces the following:
+\[\definedas\]
 which can be used e.g. in the following context:
-\[\mathbf{b}_i^r \mdefinedas (1 - t) \cdot \mathbf{b}_i^{r - 1} + t \cdot \mathbf{b}_{i + 1}^{r - 1}\]
+\[\mathbf{b}_i^r \definedas (1 - t) \cdot \mathbf{b}_i^{r - 1} + t \cdot \mathbf{b}_{i + 1}^{r - 1}\]
 
 \subsection{Conditions}
 \environmentcmd{conditions}\footnote{see \url{https://tex.stackexchange.com/a/95842}} can be used for the following:

--- a/index.tex
+++ b/index.tex
@@ -5,13 +5,14 @@
 %%% PLACE CUSTOM STYLES HERE
 %%%
 
+\selectlanguage{english}
+
 \title{Title}
 \author{Author}
 \matrikelnr{12345678}
 
 \begin{document}
 \maketitle
-\selectlanguage{english}
 
 %%%
 %%% PLACE CONTENT HERE

--- a/latexindent.yaml
+++ b/latexindent.yaml
@@ -1,0 +1,2 @@
+lookForAlignDelims:
+  conditions: 1

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -245,10 +245,10 @@ shorten >=2pt
 % ceil and floor
 \DeclarePairedDelimiter\ceil{\lceil}{\rceil}%
 \DeclarePairedDelimiter\floor{\lfloor}{\rfloor}%
-% mappliesto
-\DeclareMathOperator{\mappliesto}{,\quad}
-% mdefinedas
-\DeclareMathOperator{\mdefinedas}{\coloneqq}
+% appliesto
+\DeclareMathOperator{\appliesto}{,\quad}
+% definedas
+\DeclareMathOperator{\definedas}{\coloneqq}
 
 %%% CONDITIONS
 \newenvironment{conditions}[1][\dots]{%

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -21,6 +21,7 @@
 \RequirePackage{amssymb} % math symbols
 \RequirePackage{mathtools} % enhances amsmath
 \RequirePackage{amsthm} % 
+\RequirePackage{siunitx} % SI units
 \RequirePackage{microtype} % improves the spacing between words and letters
 \RequirePackage{enumitem} % horizontal lists
 \RequirePackage{graphicx} % graphics, images

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -1,10 +1,10 @@
 %%% TUWIEN ASSIGNMENT TEMPLATE
 % Author: Simon Josef Kreuzpointner
-% Date: 01.02.2024
-% Version: 0.4.0
+% Date: 07.03.2024
+% Version: 0.5.0
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{tuwienassignment}[2024/02/01 inofficial TU Vienna assigment template]
+\ProvidesPackage{tuwienassignment}[2024/03/07 inofficial TU Vienna assigment template]
 
 % PACKAGES
 \RequirePackage[a4paper,top=3cm,bottom=2cm,left=2cm,right=2cm,headsep=1cm]{geometry} % layout
@@ -230,15 +230,15 @@ shorten >=2pt
 % math set
 \DeclarePairedDelimiter\mset{\lbrace}{\rbrace}%
 \makeatletter
-\DeclareRobustCommand{\msetmid}{\@ifstar{\@msetmid}{\@@msetmid}}
-\newcommand{\@msetmid}[2]{\ensuremath{\mset*{#1 \mid #2}}}
-\newcommand{\@@msetmid}[2]{\ensuremath{\mset{#1 \mid #2}}}
+\DeclareRobustCommand{\msetmid}{\@ifstar{\@msetmid}{\@@msetmid}}%
+\newcommand{\@msetmid}[2]{\ensuremath{\mset*{#1 \mid #2}}}%
+\newcommand{\@@msetmid}[2]{\ensuremath{\mset{#1 \mid #2}}}%
 \makeatother
 % math tuple
 \DeclarePairedDelimiter\mtupel{\langle}{\rangle}%
 % logical true and false
-\newcommand{\ltrue}{\top}
-\newcommand{\lfalse}{\bot}
+\newcommand{\ltrue}{\top}%
+\newcommand{\lfalse}{\bot}%
 % abs and norm
 \DeclarePairedDelimiter\abs{\lvert}{\rvert}%
 \DeclarePairedDelimiter\norm{\lVert}{\rVert}%
@@ -246,9 +246,9 @@ shorten >=2pt
 \DeclarePairedDelimiter\ceil{\lceil}{\rceil}%
 \DeclarePairedDelimiter\floor{\lfloor}{\rfloor}%
 % appliesto
-\DeclareMathOperator{\appliesto}{,\quad}
+\DeclareMathOperator{\appliesto}{,\quad}%
 % definedas
-\DeclareMathOperator{\definedas}{\coloneqq}
+\DeclareMathOperator{\definedas}{\coloneqq}%
 
 %%% CONDITIONS
 \newenvironment{conditions}[1][\dots]{%

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -228,31 +228,27 @@ shorten >=2pt
 
 %%% NEW COMMANDS
 % math set
+\DeclarePairedDelimiter\mset{\lbrace}{\rbrace}%
 \makeatletter
-\DeclareRobustCommand{\mset}{\@ifstar{\@@mset}{\@mset}}
-\newcommand{\@mset}[1]{\ensuremath{\left\{ \ifthenelse{\equal{#1}{}}{}{\, #1 \,} \right\}}}
-\newcommand{\@@mset}[1]{\ensuremath{\left\{ \, \ifthenelse{\equal{#1}{}}{\emptyset}{#1} \, \right\}}}
+\DeclareRobustCommand{\msetmid}{\@ifstar{\@msetmid}{\@@msetmid}}
+\newcommand{\@msetmid}[2]{\ensuremath{\mset*{#1 \mid #2}}}
+\newcommand{\@@msetmid}[2]{\ensuremath{\mset{#1 \mid #2}}}
 \makeatother
-\newcommand{\msetmid}[2]{\ensuremath{\mset{ #1 \msetmidsa #2 }}}
-\newcommand{\msetmidsa}{\ensuremath{\, \middle| \,}}
 % math tuple
-\newcommand{\mtupel}[1]{\ensuremath{\left\langle \ifthenelse{\equal{#1}{}}{}{\, #1 \,} \right\rangle}}
+\DeclarePairedDelimiter\mtupel{\langle}{\rangle}%
 % logical true and false
 \newcommand{\ltrue}{\top}
 \newcommand{\lfalse}{\bot}
 % abs and norm
 \DeclarePairedDelimiter\abs{\lvert}{\rvert}%
 \DeclarePairedDelimiter\norm{\lVert}{\rVert}%
-\makeatletter
-\let\oldabs\abs
-\def\abs{\@ifstar{\oldabs}{\oldabs*}}
-\let\oldnorm\norm
-\def\norm{\@ifstar{\oldnorm}{\oldnorm*}}
-\makeatother
+% ceil and floor
+\DeclarePairedDelimiter\ceil{\lceil}{\rceil}%
+\DeclarePairedDelimiter\floor{\lfloor}{\rfloor}%
 % mappliesto
-\newcommand{\mappliesto}{\ensuremath{,\quad}}
+\DeclareMathOperator{\mappliesto}{,\quad}
 % mdefinedas
-\newcommand{\mdefinedas}{\ensuremath{:=}}
+\DeclareMathOperator{\mdefinedas}{\coloneqq}
 
 %%% CONDITIONS
 \newenvironment{conditions}[1][\dots]{%


### PR DESCRIPTION
- refactor commands:
  - `abs`
  - `norm`
  - `mset`
  - `msetmid`
  - `mtupel`
  - These commands now provide a consistent syntax for the starred versions. The starred versions scale vertically.
  - `mtupel` is now nestable
  - `definedas` now looks better
- add commands:
  - `ceil`
  - `floor`
- rename commands:
  - `mappliesto` to `appliesto`
  - `mdefinedas` to `definedas`
- remove commands:
  - `\msetmidsa`
- add latex indent config file to provide proper formatting of the `conditions` environment. To use this local config, make sure to use the `-l` switch. Read more [here](https://latexindentpl.readthedocs.io/en/latest/sec-indent-config-and-settings.html#localsettings-yaml-and-friends).
- add `siunix` package