### PR TITLE
develop to main

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -1,10 +1,14 @@
 \documentclass[10pt]{article}
 \usepackage{tuwienassignment}
 
+\usepackage{listings}
 \usepackage{lipsum} % dummy text
-\newcommand{\environmentcmd}[1]{\par\noindent\textbf{Environment:} \lstinline{#1}}
-\newcommand{\commandcmd}[1]{\par\noindent\textbf{Command:} \lstinline{\\#1}}
-\newcommand{\commandscmd}[2]{\par\noindent\textbf{Commands:} \lstinline{\\#1} and \lstinline{\\#2}}
+\lstset{
+    basicstyle=\ttfamily
+}
+\newcommand{\environmentcmd}[1]{\par\noindent\textbf{Environment:} \lstinline^#1^}
+\newcommand{\commandcmd}[1]{\par\noindent\textbf{Command:} \lstinline^\\#1^}
+\newcommand{\commandscmd}[2]{\par\noindent\textbf{Commands:} \lstinline^\\#1^ and \lstinline^\\#2^}
 
 %%%
 %%% PLACE CUSTOM STYLES HERE
@@ -73,8 +77,9 @@
 \section{Exercises and Solutions}
 \environmentcmd{exercise} produces a numbered exercise, which prefixes the current section on their counter. The section can correspond to each exercise sheet for example.
 
-\environmentcmd{solution} produces a numbered solution. A solution has to be placed \emph{inside} of the exercise. Solutions will be numbered accordingly inside of an exercise environment. The number for a solution can be changed by writing the macro \lstinline|\setcounter{solutioncounter}{x}| where \lstinline{x} is the number the counter should be set to.
-The numberformat can also be changed by calling the macro \lstinline|\renewcommand{\thesolutioncounter}{x}| where \lstinline{x} is the format. For example for roman numerals it would be \lstinline|\roman{solutioncounter}|.
+\environmentcmd{solution} produces a numbered solution. A solution has to be placed \emph{inside} of the exercise. Solutions will be numbered accordingly inside of an exercise environment. The number for a solution can be changed by writing the macro \lstinline^\setcounter{solutioncounter}{x}^ where \lstinline^x^ is the number the counter should be set to.
+
+The numberformat can also be changed by calling the macro \lstinline^\renewcommand{\thesolutioncounter}{x}^ where \lstinline^x^ is the format. For example for roman numerals it would be \lstinline^\roman{solutioncounter}^.
 
 \begin{exercise}
   \lipsum[1-1]
@@ -247,103 +252,6 @@ It is possible to have different symbols instead of the dots:
 \end{table}
 
 Please note, that this only works in \emph{tabularx} columns.
-
-\section{lstlistings}
-
-\subsection{Python}
-\begin{lstlisting}[caption=Example in Python,language=python]
-import numpy as np
-    
-def incmatrix(genl1,genl2):
-    m = len(genl1)
-    n = len(genl2)
-    M = None #to become the incidence matrix
-    VT = np.zeros((n*m,1), int)  #dummy variable
-    
-    #compute the bitwise xor matrix
-    M1 = bitxormatrix(genl1)
-    M2 = np.triu(bitxormatrix(genl2),1) 
-
-    for i in range(m-1):
-        for j in range(i+1, m):
-            [r,c] = np.where(M2 == M1[i,j])
-            for k in range(len(r)):
-                VT[(i)*n + r[k]] = 1;
-                VT[(i)*n + c[k]] = 1;
-                VT[(j)*n + r[k]] = 1;
-                VT[(j)*n + c[k]] = 1;
-                
-                if M is None:
-                    M = np.copy(VT)
-                else:
-                    M = np.concatenate((M, VT), 1)
-                
-                VT = np.zeros((n*m,1), int)
-    
-    return M
-\end{lstlisting}
-
-\subsection{C++}
-
-\begin{lstlisting}[caption=Example in C++,language=c++]
-#include <iostream>
-using namespace std;
-
-int main() {
-    int n, t1 = 0, t2 = 1, nextTerm = 0;
-
-    cout << "Enter the number of terms: ";
-    cin >> n;
-
-    cout << "Fibonacci Series: ";
-
-    for (int i = 1; i <= n; ++i) {
-        // Prints the first two terms.
-        if(i == 1) {
-            cout << t1 << ", ";
-            continue;
-        }
-        if(i == 2) {
-            cout << t2 << ", ";
-            continue;
-        }
-        nextTerm = t1 + t2;
-        t1 = t2;
-        t2 = nextTerm;
-        
-        cout << nextTerm << ", ";
-    }
-    return 0;
-}
-\end{lstlisting}
-
-\subsection{Output}
-
-\begin{lstlisting}[style=lstoutput]
-Enter a positive integer: 100
-Fibonacci Series: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 
-\end{lstlisting}
-
-\subsection{Pseudocode}
-
-\begin{lstlisting}[caption=Example in Pseudo,language=pseudo]
-function Tree-Search(problem) returns a solution, or failure
-  initialize the frontier using the initial state of problem
-  loop do
-    if the frontier is empty then return failure
-    choose a leaf node and remove it from the frontier
-    if the node contains a goal state then return the corresponding solution
-    expand the chosen node, adding the resulting nodes to the frontier
-\end{lstlisting}
-
-\subsection{Standard}
-
-\begin{lstlisting}[caption=Very long line]
-This is a very very very very very very very very very very very very very very very very very very very very very long line.
-\end{lstlisting}
-
-\subsection{File Input}
-\lstinputlisting[caption=Example in C,language=C]{example.c}
 
 \section{Images}
 Take a look at this example image: \footnote{Copyright free image from \url{https://pixabay.com/illustrations/background-pattern-lemon-texture-6703215/}}

--- a/scripts/example.c
+++ b/scripts/example.c
@@ -1,7 +1,0 @@
-#include <stdio.h>
-
-int main()
-{
-	printf("%s", "Hello World");
-	return 0;
-}

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -1,10 +1,10 @@
 %%% TUWIEN ASSIGNMENT TEMPLATE
 % Author: Simon Josef Kreuzpointner
-% Date: 16.03.2024
-% Version: 0.6.0
+% Date: 19.03.2024
+% Version: 0.7.0
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{tuwienassignment}[2024/03/16 inofficial TU Vienna assigment template]
+\ProvidesPackage{tuwienassignment}[2024/03/19 inofficial TU Vienna assigment template]
 
 % PACKAGES
 \RequirePackage[a4paper,top=3cm,bottom=2cm,left=2cm,right=2cm,headsep=1cm]{geometry} % layout

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -273,6 +273,8 @@ shorten >=2pt
 % counters
 \newcounter{exercisecounter}
 \newcounter{solutioncounter}
+\counterwithin{exercisecounter}{section}
+\counterwithin{solutioncounter}{exercisecounter}
 % exercise
 \newif\ifshowexercisepoints
 \pgfkeys{
@@ -320,21 +322,16 @@ shorten >=2pt
   \fi
 }
 %environment
-\newenvironment{exercise}[1][]{
-  \pgfkeys{/exercise, default, #1}
-  \bigskip%
-  \noindent%
-  \setcounter{solutioncounter}{1}%
+\newenvironment{exercise}[1][]{%
+  \pgfkeys{/exercise, default, #1}%
   \refstepcounter{exercisecounter}%
+  \vskip\bigskipamount\noindent%
   \bgroup\bfseries\large%
   \exercisetitle \printexercisecounter \printexercisesubtitle \printexercisepoints%
   \egroup%
-  \newline%
-}{
-  \par%
-  \bigskip%
-}
-\counterwithin{exercisecounter}{section}
+  \vskip\medskipamount\noindent%
+  \label{exe:\arabic{exercisecounter}}%
+}{}
 % solution
 % solution title
 \newcommand{\formatsolutiontitle}{\solutiontitle}
@@ -343,18 +340,14 @@ shorten >=2pt
 \newcommand{\formatsolutioncounter}{\ \thesolutioncounter}
 \newcommand{\printsolutioncounter}{\formatsolutioncounter}
 % environment
-\newenvironment{solution}[1][]{
-  \pgfkeys{/exercise/solution, #1}
-  \par%
-  \medskip%
-  \noindent%
+\newenvironment{solution}[1][]{%
+  \pgfkeys{/exercise/solution, #1}%
+  \refstepcounter{solutioncounter}%
+  \vskip\medskipamount\noindent%
   \bgroup%
   \bfseries\normalsize%
   \printsolutiontitle \printsolutioncounter%
   \egroup%
-  \newline%
-}{
-  \refstepcounter{solutioncounter}%
-  \par%
-  \medskip%
-}
+  \vskip\smallskipamount\noindent%
+  \label{sol:\arabic{solutioncounter}}%
+}{}

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -160,6 +160,9 @@
 \renewcommand{\theadalign}{cl}
 \renewcommand{\cellalign}{tl}
 
+%%% SIUNIX
+\sisetup{group-separator={\ }}
+
 %%% NEW COMMANDS
 % math set
 \DeclarePairedDelimiter\mset{\lbrace}{\rbrace}%

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -23,7 +23,7 @@
 \RequirePackage{amsthm} % 
 \RequirePackage{siunitx} % SI units
 \RequirePackage{microtype} % improves the spacing between words and letters
-\RequirePackage{enumitem} % horizontal lists
+\RequirePackage[inline]{enumitem} % horizontal lists
 \RequirePackage{graphicx} % graphics, images
 \RequirePackage{array} % extension of array and tabular environments
 \RequirePackage{xcolor} % work with colors

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -38,6 +38,7 @@
 \RequirePackage{tikz} % draw diagrams and figures
 \RequirePackage{varwidth} % variable width mini-page
 \RequirePackage{float} % 
+\RequirePackage{subcaption} % subfigure
 \RequirePackage{chngcntr} % new counter macros
 % MUST BE PLACED LAST
 \RequirePackage[colorlinks=true, allcolors=blue]{hyperref}

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -34,7 +34,6 @@
 \RequirePackage{nicematrix} % better matrices
 \RequirePackage{multirow} % allow multirow cells
 \RequirePackage{makecell} % table cell configuration
-\RequirePackage{listings} % code listing
 \RequirePackage{pgfkeys} % pgf keys
 \RequirePackage{tikz} % draw diagrams and figures
 \RequirePackage{varwidth} % variable width mini-page
@@ -130,72 +129,6 @@
         after ={\end{minipage}}
 }
 
-%%% LSTLISTING STYLE
-\lstdefinestyle{lststandardstyle}{
-  backgroundcolor=\color{codelightgray},
-  basicstyle=\ttfamily,
-  breakatwhitespace=false,
-  breaklines=true,
-  captionpos=t,
-  commentstyle=\color{codegray},
-  deletekeywords={},
-  extendedchars=true,
-  firstnumber=1,
-  frame=single,
-  keepspaces=true,
-  keywordstyle=\color{codeblue}\bfseries,
-  morekeywords={*,...},
-  numbers=left,
-  numbersep=5pt,
-  numberstyle=\sffamily\small\color{codegray},
-  rulecolor=\color{black},
-  showspaces=false,
-  showstringspaces=false,
-  showtabs=false,
-  stepnumber=1,
-  stringstyle=\color{codegreen},
-  tabsize=4,
-  escapeinside={(*}{*)},
-  linewidth=\columnwidth,
-  xleftmargin=3.4pt,
-  xrightmargin=3.4pt,
-  postbreak=\mbox{\textcolor{gray}{\(\hookrightarrow\)}\space},
-}
-\lstdefinestyle{lstoutput}{
-  backgroundcolor=\color{codelightgray},
-  basicstyle=\ttfamily,
-  breakatwhitespace=false,
-  breaklines=true,
-  captionpos=t,
-  extendedchars=true,
-  firstnumber=1,
-  frame=single,
-  keepspaces=true,
-  rulecolor=\color{black},
-  stepnumber=0,
-  tabsize=4,
-  title=Output,
-  escapeinside={(*}{*)},
-}
-\lstdefinelanguage{pseudo}{
-  mathescape=true,
-  basicstyle=,
-  keywordstyle=\color{black}\bfseries\em,
-  morekeywords={function, returns, return, if, then, else, and, or, not, loop, do, while, for, each, switch, case, foreach, begin, end, endif, until, repeat, null},
-  sensitive=false,
-  morecomment=[l]{//},
-  morecomment=[s]{/*}{*/},
-  morestring=[b]"
-}
-\lstset{
-  style=lststandardstyle,
-  framerule=0.8pt,
-  rulesep=0pt,
-  inputpath={{./scripts/}}
-}
-
-\newcommand{\lstinputpath}[1]{\lstset{inputpath=#1}}
-
 %%% TIKZ
 % tikz libraries
 \usetikzlibrary{
@@ -208,15 +141,6 @@
 
 % default node distance
 \tikzset{node distance=1cm}
-
-\tikzstyle{arrow} = [
-very thick,
-->,
--stealth,
-rounded corners=3mm,
-shorten <=2pt,
-shorten >=2pt
-]
 
 %%% PGF LAYERS
 % declare a new background layer beneath the main layer


### PR DESCRIPTION
- adjust spacing for `solution` and `exercise` environments
- add labels for `solution` and `exercise` environments of the form `sol:<index>` and `exe:<index>` respectively
- remove `listings` package, for a better support of the previous settings take a look at [moderncode](https://github.com/Smonman/moderncode)
- remove command `\lstinputpath`
- remove `tikz` style called `arrow`
- add `inline` option to `enumitem`
- set thousands separator for `siunix` to a whitespace