### PR TITLE
develop to main

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -182,16 +182,16 @@ The numberformat can also be changed by calling the macro \lstinline^\renewcomma
         \[\msetmid*{x}{x \in \mset{a}}\]
 \end{itemize}
 
-\commandcmd{mtupel} produces the following:
+\commandcmd{mtuple} produces the following:
 \begin{itemize}
   \item \emph{non-starred}:
-        \[\mtupel{1, 2, 3, 4}\]
-        \[\mtupel{\frac{1}{2}, \frac{2}{3}}\]
-        \[\mtupel{}\]
+        \[\mtuple{1, 2, 3, 4}\]
+        \[\mtuple{\frac{1}{2}, \frac{2}{3}}\]
+        \[\mtuple{}\]
   \item \emph{starred}:
-        \[\mtupel*{1, 2, 3, 4}\]
-        \[\mtupel*{\frac{1}{2}, \frac{2}{3}}\]
-        \[\mtupel*{}\]
+        \[\mtuple*{1, 2, 3, 4}\]
+        \[\mtuple*{\frac{1}{2}, \frac{2}{3}}\]
+        \[\mtuple*{}\]
 \end{itemize}
 
 \subsection{Other}
@@ -203,7 +203,7 @@ which can be used e.g. in the following context:
 
 \commandcmd{definedas} produces the following:
 \[\definedas\]
-which can be used e.g. in the following context:
+which can be used e.g.\ in the following context:
 \[\mathbf{b}_i^r \definedas (1 - t) \cdot \mathbf{b}_i^{r - 1} + t \cdot \mathbf{b}_{i + 1}^{r - 1}\]
 
 \subsection{Conditions}
@@ -240,7 +240,7 @@ It is possible to have different symbols instead of the dots:
   \centering
   \begin{tabularx}{0.5\linewidth}{Y}
     \toprule
-    Header            \\
+    \thead{Header}    \\
     \midrule
     \begin{tabitemize}
       \item item 1
@@ -254,12 +254,11 @@ It is possible to have different symbols instead of the dots:
 Please note, that this only works in \emph{tabularx} columns.
 
 \section{Images}
-Take a look at this example image: \footnote{Copyright free image from \url{https://pixabay.com/illustrations/background-pattern-lemon-texture-6703215/}}
+Take a look at this example image\footnote{Copyright free image from \url{https://pixabay.com/illustrations/background-pattern-lemon-texture-6703215/}}:
 \begin{figure}[h!t]
   \centering
-  \includegraphics[scale=0.5]{happy_lemons.png}
-  \caption{Happy Lemons}
-  \label{fig:happylemons}
+  \includegraphics[scale=0.25]{happy_lemons.png}
+  \caption{\label{fig:happylemons}Happy Lemons}
 \end{figure}
 
 \end{document}

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -47,7 +47,6 @@
 \usepackage{glossaries-extra}
 
 %%% COLORS
-% standard colors
 \definecolor{myyellow}{rgb}{0.94, 0.82, 0.007}
 \definecolor{myred}{rgb}{0.75, 0.16, 0.18}
 \definecolor{myblue}{rgb}{0.13, 0.34, 0.53}
@@ -55,11 +54,6 @@
 \definecolor{mylightblue}{rgb}{0.39, 0.68, 1}
 \definecolor{mydarkgreen}{rgb}{0, 0.4, 0}
 \definecolor{mysmoke}{rgb}{0.9, 0.9, 0.9}
-% lstlisting
-\definecolor{codegray}{HTML}{707070}
-\definecolor{codelightgray}{HTML}{FAFAFA}
-\definecolor{codegreen}{HTML}{24751B}
-\definecolor{codeblue}{HTML}{1733BF}
 
 %%% GRAPHICS PATH
 \graphicspath{{./img/}}
@@ -73,7 +67,7 @@
 \author{}
 \matrikelnr{}
 
-%%% Set PDF document properties
+%%% PDF DOCUMENT PROPERTIES
 \hypersetup{%
   final,
   pdfpagelayout   = SinglePage,
@@ -141,6 +135,12 @@
   before={\begin{minipage}[t]{\linewidth}},
         after ={\end{minipage}}
 }
+
+\newlist{enumerateinline}{enumerate*}{1}
+\setlist[enumerateinline]{label={(\roman{*})}}
+
+\newlist{enumeratekeywords}{enumerate}{2}
+\setlist[enumeratekeywords]{leftmargin=*,align=left,font=\ttfamily\bfseries,label={}}
 
 %%% TIKZ
 % tikz libraries

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -1,17 +1,18 @@
 %%% TUWIEN ASSIGNMENT TEMPLATE
 % Author: Simon Josef Kreuzpointner
-% Date: 19.03.2024
-% Version: 0.7.0
+% Date: 23.09.2024
+% Version: 0.8.0
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{tuwienassignment}[2024/03/19 inofficial TU Vienna assigment template]
+\ProvidesPackage{tuwienassignment}[2024/09/23 inofficial TU Vienna assigment template]
 
 % PACKAGES
 \RequirePackage[a4paper,top=3cm,bottom=2cm,left=2cm,right=2cm,headsep=1cm]{geometry} % layout
+\RequirePackage{lmodern} % Use an extension of the original Computer Modern font to minimize the use of bitmapped letters.
 \RequirePackage[utf8]{inputenc} % input encoding
 \RequirePackage[T1]{fontenc} % font encoding for umlaute
 \RequirePackage[naustrian,english]{babel} % language
-\RequirePackage{csquotes} % enqote
+\RequirePackage[autostyle]{csquotes} % enqote
 \RequirePackage{iflang} % conditional statements based on selected language
 \RequirePackage{ifthen} % for conditinal branching
 \RequirePackage[skip=4pt, indent=10pt]{parskip} % spacing between paragraphs
@@ -41,7 +42,9 @@
 \RequirePackage{subcaption} % subfigure
 \RequirePackage{chngcntr} % new counter macros
 % MUST BE PLACED LAST
-\RequirePackage[colorlinks=true, allcolors=blue]{hyperref}
+\RequirePackage{hyperref}
+\usepackage[acronym,toc]{glossaries} % Enables the generation of glossaries and lists of acronyms. This package has to be included after bable, fontenc, inputenc and hyperref
+\usepackage{glossaries-extra}
 
 %%% COLORS
 % standard colors
@@ -58,7 +61,7 @@
 \definecolor{codegreen}{HTML}{24751B}
 \definecolor{codeblue}{HTML}{1733BF}
 
-%%% GRAPHIXS PATH
+%%% GRAPHICS PATH
 \graphicspath{{./img/}}
 
 %%% TITLE, SUBTITLE, MATRIKELNR
@@ -69,6 +72,15 @@
 \subtitle{}
 \author{}
 \matrikelnr{}
+
+%%% Set PDF document properties
+\hypersetup{%
+  final,
+  pdfpagelayout   = SinglePage,
+  pdfauthor       = {\@author},
+  pdftitle        = {\@title},
+  pdfdisplaydoctitle = true
+}
 
 %%% TITLE STYLE
 \newcommand{\authormatrikelnrspacing}{\ifthenelse{\equal{\@author}{}}{}{\ }}
@@ -133,11 +145,16 @@
 %%% TIKZ
 % tikz libraries
 \usetikzlibrary{
-  shapes.geometric,
-  arrows,
-  positioning,
+  arrows.meta,
+  backgrounds,
   bending,
-  fit
+  calc,
+  decorations.pathmorphing,
+  decorations.pathreplacing,
+  fit,
+  matrix,
+  positioning,
+  shapes.geometric
 }
 
 % default node distance
@@ -172,7 +189,7 @@
 \newcommand{\@@msetmid}[2]{\ensuremath{\mset{\, #1 \mid #2 \,}}}%
 \makeatother
 % math tuple
-\DeclarePairedDelimiter\mtupel{\langle}{\rangle}%
+\DeclarePairedDelimiter\mtuple{\langle}{\rangle}%
 % logical true and false
 \newcommand{\ltrue}{\top}%
 \newcommand{\lfalse}{\bot}%


### PR DESCRIPTION
- add `lmodern` package
- add `glossaries` package
- add `glossaries-extra` package
- add `autostyle` option to `csquotes`
- add hypersetup for the PDF author and PDF title among other things
- bump TikZ library `arrows` to `arrows.meta`
- add TiKZ library `backgrounds`, `calc`, `decorations.pathmorphing`, `decorations.pathreplacing` and `matrix`
- add custom lists `enumerateinline` and `enumeratekeywords`
- rename command `\mtupel` to `\mtuple`
- remove link coloring
- remove listing colors