### PR TITLE
develop to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # tuwien-assignment-template
 
-An inofficial Latex template for TU Vienna assignments. Take a look at the [example](https://github.com/Smonman/tuwien-assignment-template/blob/main/example.pdf).
+An in-official Latex template for TU Vienna assignments. Take a look at the [example](https://github.com/Smonman/tuwien-assignment-template/blob/main/example.pdf).
 
 _This Latex template aims to streamline the writing of digital assignments._
 
 ## Why should I use this template?
 
-Writing assignments isn't necessarily a joyful activity. Out of a need to reduce workload this template was written. Its purpose is not to be an efficient lightweight template but rather a fully loaded, plug-and-play, out of the box template. It provides additional commands to help specificly with assignments. The idea was that one can start working using this template, without worring about packages to import or settings to change.
+Writing assignments isn't necessarily a joyful activity. Out of a need to reduce workload this template was written. Its purpose is not to be an efficient lightweight template but rather a fully loaded, plug-and-play, out of the box template. It provides additional commands to help specifically with assignments. The idea was that one can start working using this template, without worrying about packages to import or settings to change.
 
 ## How do I use this template?
 
-Download the latest version of this template [here](https://github.com/Smonman/tuwien-assignment-template/releases). When using [Overleaf](https://www.overleaf.com/project) press "New Project" > "Upload Project" and select the downloaded ZIP archive.
+Download the latest version of this template from the [release page](https://github.com/Smonman/tuwien-assignment-template/releases). When using [Overleaf](https://www.overleaf.com/project) press "New Project" > "Upload Project" and select the downloaded ZIP archive.
 
 ## What can this template do?
 
-This template comes with a sleek design that is kept closely to the originial Latex article style. It also provides environments for exercises and solutions. Which are conveniently numbered.
+This template comes with a sleek design that is kept closely to the original Latex article style. It also provides environments for exercises and solutions. Which are conveniently numbered.
 
 This template loads a bunch of other packages:
 
@@ -26,9 +26,6 @@ This template loads a bunch of other packages:
 - `csquotes`
 - `iflang`
 - `ifthen`
-- `parskip`
-- `titling`
-- `fancyhdr`
 - `amsfonts`
 - `amsmath`
 - `amssymb`
@@ -48,6 +45,7 @@ This template loads a bunch of other packages:
 - `nicematrix`
 - `multirow`
 - `makecell`
+- `listings`
 - `pgfkeys`
 - `tikz`
 - `varwidth`
@@ -60,7 +58,7 @@ This template loads a bunch of other packages:
 
 ### Exercises and Solutions
 
-`exercise` is an environment for the exercises, including the solutions. Exercises are numbered within a `section`. The idea is, that each section represents a singe exercise sheet. Inside of this `exercise` environment can multiple `solution` environments be declared. These are numbered within the parent exercise environment.
+`exercise` is an environment for the exercises, including the solutions. Exercises are numbered within a `section`. The idea is, that each section represents a singe exercise sheet. Inside this `exercise` environment multiple `solution` environments can be declared. These are numbered within the parent exercise environment.
 
 If you don't want to number the exercises according to the section, just use this macro:
 
@@ -68,7 +66,7 @@ If you don't want to number the exercises according to the section, just use thi
 \counterwithout{exercisecounter}{section}
 ```
 
-There are also minute possibilities to customise these environments. Each `exercise` environment has the following keys:
+There are also minute possibilities to customize these environments. Each `exercise` environment has the following keys:
 
 - `title` the title of the exercise (default "Exercise")
 - `subtitle` the subtitle of the exercise (default empty)
@@ -86,7 +84,8 @@ If a specific solution counter should be set to a specific value, this can be do
 
 macro, where `x` is the new starting number for the counter.
 
-> **Note**: that the following solutions will also be affected.
+> [!NOTE]
+> that the following solutions will also be affected.
 
 If the numbering style of the solutions within an `exercise` environment should be changed, this currently cannot be done via keys, but has to be done _manually_ via the command:
 
@@ -94,13 +93,13 @@ If the numbering style of the solutions within an `exercise` environment should 
 \renewcommand{\thesolutioncounter}{(\roman{solutioncounter})}
 ```
 
-at the top inside of the corresponding `exercise` environment. In this case, the enumeration will be lowercase roman numerals in braces.
+at the top inside the corresponding `exercise` environment. In this case, the enumeration will be lowercase roman numerals in braces.
 
 ### Math
 
 The packages [`amsmath`](https://ctan.org/pkg/amsmath), `amssymb`, [`mathtools`](https://ctan.org/pkg/mathtools) and [`amsthm`](https://ctan.org/pkg/amsthm) are already supplied via the template. Writing proofs and theorems can be done easily via the environments provided by the `amsthm` package. Take a look at [this guide](https://de.overleaf.com/learn/latex/Theorems_and_proofs) for more details.
 
-Moreover some math-related commands are changed or added:
+Moreover, some math-related commands are changed or added:
 
 | command | has starred version | description |
 | --- | --- | --- |
@@ -115,6 +114,10 @@ Moreover some math-related commands are changed or added:
 | `\definedas` | no | creates a colon with an equal sign |
 | `\ltrue` | no | alias for verum |
 | `\lfalse` | no | alias for falsum |
+| `\intervaloo` | no | interval (open, open) |
+| `\intervaloc` | no | interval (open, closed) |
+| `\intervalco` | no | interval (closed, open) |
+| `\intervalcc` | no | interval (closed, closed) |
 
 | environment | description |
 | --- | --- |
@@ -124,9 +127,9 @@ For more details regarding Latex in general take a look at this [cheatsheet](htt
 
 ### Language
 
-The package [`babel`](https://ctan.org/pkg/babel) is used for language support. With the standard being Englisch. Additionally the package [`csquotes`](https://ctan.org/pkg/csquotes) is imported, for correct quotes based on the primary language selected via `babel`.
+The package [`babel`](https://ctan.org/pkg/babel) is used for language support. With the standard being English. Additionally, the package [`csquotes`](https://ctan.org/pkg/csquotes) is imported, for correct quotes based on the primary language selected via `babel`.
 
-You can change the language associated with the document by changing this line right after the begin of the document:
+You can change the language associated with the document by changing this line right after the begining of the document:
 
 ```tex
 \selectlanguage{english}
@@ -146,9 +149,26 @@ command.
 
 ### Header
 
-The author, matrikelnr, date, title and subtitle are optional, and default to an empty string.
+The author, Matrikel-Number, date, title and subtitle are optional, and default to an empty string.
 
 ## Changelog
+
+### 0.11.0
+
+- remove `parskip` package
+- remove `titling` package
+- remove `fancyhdr` package
+- the template now expects a document class from the KOMAscript universe
+- the Matrikel-Number now has to be supplied inside the author field
+- the `geometry` package is no longer supplied with the `a4paper` key
+- the margins have been changed to 2 cm horizontal and 3 cm vertical
+- migrate all commands to use the newer `\NewDocumentCommand` functionality
+- migrate all environments to use the newer `\NewDocumentEnvironment` functionality
+- add `\intervaloo`, `\intervaloc`, `\intervalco`, `\intervalcc`
+- the `exercise` environment now _behaves_ like a `subsection`
+- the `solution` environment now _behaves_ like a `subsubsection`
+- the `exercise` and `solution` environment are now correctly shown in the TOC
+- rename colors prefix from "my" to "tua"
 
 ### 0.9.0
 

--- a/example.tex
+++ b/example.tex
@@ -1,11 +1,8 @@
-\documentclass[10pt]{article}
+\documentclass[a4paper,10pt,oneside]{scrartcl}
 \usepackage{tuwienassignment}
 
-\usepackage{listings}
 \usepackage{lipsum} % dummy text
-\lstset{
-    basicstyle=\ttfamily
-}
+
 \newcommand{\environmentcmd}[1]{\par\noindent\textbf{Environment:} \lstinline^#1^}
 \newcommand{\commandcmd}[1]{\par\noindent\textbf{Command:} \lstinline^\\#1^}
 \newcommand{\commandscmd}[2]{\par\noindent\textbf{Commands:} \lstinline^\\#1^ and \lstinline^\\#2^}
@@ -17,11 +14,12 @@
 \selectlanguage{english}
 
 \title{Title}
-\author{Author}
-\matrikelnr{12345678}
+\subtitle{Subtitle}
+\author{Author \matrikelnr{12345678}}
 
 \begin{document}
 \maketitle
+\tableofcontents
 
 \section{Introduction}
 \lipsum[1-1]
@@ -99,36 +97,36 @@
 \section{Exercises and Solutions}
 \environmentcmd{exercise} produces a numbered exercise, which prefixes the current section on their counter. The section can correspond to each exercise sheet for example.
 
-\environmentcmd{solution} produces a numbered solution. A solution has to be placed \emph{inside} of the exercise. Solutions will be numbered accordingly inside of an exercise environment. The number for a solution can be changed by writing the macro \lstinline^\setcounter{solutioncounter}{x}^ where \lstinline^x^ is the number the counter should be set to.
+\environmentcmd{solution} produces a numbered solution. A solution has to be placed \emph{inside} the exercise. Solutions will be numbered accordingly inside an exercise environment. The number for a solution can be changed by writing the macro \lstinline^\setcounter{solutioncounter}{x}^ where \lstinline^x^ is the number the counter should be set to.
 
-The numberformat can also be changed by calling the macro \lstinline^\renewcommand{\thesolutioncounter}{x}^ where \lstinline^x^ is the format. For example for roman numerals it would be \lstinline^\roman{solutioncounter}^.
+The number-format can also be changed by calling the macro \lstinline^\renewcommand{\thesolutioncounter}{x}^ where \lstinline^x^ is the format. For example for roman numerals it would be \lstinline^\roman{solutioncounter}^.
 
-\begin{exercise}
+\begin{exercise}%
   \lipsum[1-1]
-  \begin{solution}
+  \begin{solution}%
     \lipsum[1-1]
   \end{solution}
-  \begin{solution}
+  \begin{solution}%
     \lipsum[1-1]
   \end{solution}
-  \begin{solution}
+  \begin{solution}%
     \lipsum[1-1]
   \end{solution}
 \end{exercise}
 
-\begin{exercise}[title=Übung]
+\begin{exercise}[title=Übung]%
   \lipsum[1-1]
-  \begin{solution}
+  \begin{solution}%
     \lipsum[1-1]
   \end{solution}
 \end{exercise}
 
-\begin{exercise}
+\begin{exercise}%
   \renewcommand{\thesolutioncounter}{(\roman{solutioncounter})}%
   \lipsum[1-1]
-  \begin{solution}
+  \begin{solution}%
   \end{solution}
-  \begin{solution}
+  \begin{solution}%
   \end{solution}
 \end{exercise}
 
@@ -215,6 +213,20 @@ The numberformat can also be changed by calling the macro \lstinline^\renewcomma
         \[\mtuple*{\frac{1}{2}, \frac{2}{3}}\]
         \[\mtuple*{}\]
 \end{itemize}
+
+\subsection{Intervals}
+
+\commandcmd{intervaloo} produces the following:
+\[\intervaloo{1,3}\]
+
+\commandcmd{intervaloc} produces the following:
+\[\intervaloc{1,3}\]
+
+\commandcmd{intervalco} produces the following:
+\[\intervalco{1,3}\]
+
+\commandcmd{intervalcc} produces the following:
+\[\intervalcc{1,3}\]
 
 \subsection{Other}
 

--- a/index.tex
+++ b/index.tex
@@ -1,4 +1,4 @@
-\documentclass[10pt]{article}
+\documentclass[a4paper,10pt,oneside]{scrartcl}
 \usepackage{tuwienassignment}
 
 %%%
@@ -9,8 +9,7 @@
 
 \title{Title}
 \subtitle{Subtitle}
-\author{Author}
-\matrikelnr{12345678}
+\author{Author \matrikelnr{12345678}}
 
 \begin{document}
 \maketitle

--- a/tuwienassignment.sty
+++ b/tuwienassignment.sty
@@ -1,13 +1,14 @@
 %%% TUWIEN ASSIGNMENT TEMPLATE
 % Author: Simon Josef Kreuzpointner
-% Date: 27.02.2025
-% Version: 0.10.0
+% Date: 23.03.2026
+% Version: 0.11.0
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{tuwienassignment}[2024/02/27 inofficial TU Vienna assigment template]
+\ProvidesPackage{tuwienassignment}[2026/03/23 inofficial TU Vienna assigment template]
 
 % PACKAGES
-\RequirePackage[a4paper,top=3cm,bottom=2cm,left=2cm,right=2cm,headsep=1cm]{geometry} % layout
+\RequirePackage[hmargin=2cm,vmargin=3cm,headsep=0.8cm]{geometry} % layout
+\RequirePackage{scrlayer-scrpage}
 \RequirePackage{lmodern} % Use an extension of the original Computer Modern font to minimize the use of bitmapped letters.
 \RequirePackage[utf8]{inputenc} % input encoding
 \RequirePackage[T1]{fontenc} % font encoding for umlaute
@@ -15,9 +16,6 @@
 \RequirePackage[autostyle]{csquotes} % enqote
 \RequirePackage{iflang} % conditional statements based on selected language
 \RequirePackage{ifthen} % for conditinal branching
-\RequirePackage[skip=4pt, indent=10pt]{parskip} % spacing between paragraphs
-\RequirePackage{titling} % title
-\RequirePackage{fancyhdr} % header and footer
 \RequirePackage{amsfonts} % math font
 \RequirePackage{amsmath} % math
 \RequirePackage{amssymb} % math symbols
@@ -37,6 +35,7 @@
 \RequirePackage{nicematrix} % better matrices
 \RequirePackage{multirow} % allow multirow cells
 \RequirePackage{makecell} % table cell configuration
+\RequirePackage{listings} % code listings
 \RequirePackage{pgfkeys} % pgf keys
 \RequirePackage{tikz} % draw diagrams and figures
 \RequirePackage{varwidth} % variable width mini-page
@@ -46,29 +45,20 @@
 \RequirePackage[most]{tcolorbox} %
 % MUST BE PLACED LAST
 \RequirePackage{hyperref}
-\usepackage[acronym,toc]{glossaries} % Enables the generation of glossaries and lists of acronyms. This package has to be included after bable, fontenc, inputenc and hyperref
-\usepackage{glossaries-extra}
+\RequirePackage[acronym,toc]{glossaries} % Enables the generation of glossaries and lists of acronyms. This package has to be included after bable, fontenc, inputenc and hyperref
+\RequirePackage{glossaries-extra}
 
 %%% COLORS
-\definecolor{myyellow}{rgb}{0.94, 0.82, 0.007}
-\definecolor{myred}{rgb}{0.75, 0.16, 0.18}
-\definecolor{myblue}{rgb}{0.13, 0.34, 0.53}
-\definecolor{mydarkblue}{rgb}{0.1, 0.16, 0.27}
-\definecolor{mylightblue}{rgb}{0.39, 0.68, 1}
-\definecolor{mydarkgreen}{rgb}{0, 0.4, 0}
-\definecolor{mysmoke}{rgb}{0.9, 0.9, 0.9}
+\definecolor{tuayellow}{rgb}{0.94, 0.82, 0.007}
+\definecolor{tuared}{rgb}{0.75, 0.16, 0.18}
+\definecolor{tuablue}{rgb}{0.13, 0.34, 0.53}
+\definecolor{tuadarkblue}{rgb}{0.1, 0.16, 0.27}
+\definecolor{tualightblue}{rgb}{0.39, 0.68, 1}
+\definecolor{tuadarkgreen}{rgb}{0, 0.4, 0}
+\definecolor{tuasmoke}{rgb}{0.9, 0.9, 0.9}
 
 %%% GRAPHICS PATH
 \graphicspath{{./img/}}
-
-%%% TITLE, SUBTITLE, MATRIKELNR
-\DeclareRobustCommand\subtitle[1]{\gdef\@subtitle{#1}}
-\DeclareRobustCommand\matrikelnr[1]{\gdef\@matrikelnr{#1}}
-% defaults
-\title{}
-\subtitle{}
-\author{}
-\matrikelnr{}
 
 %%% PDF DOCUMENT PROPERTIES
 \hypersetup{%
@@ -80,54 +70,86 @@
 }
 
 %%% TITLE STYLE
-\newcommand{\authormatrikelnrspacing}{\ifthenelse{\equal{\@author}{}}{}{\ }}
-% before title
-\pretitle{%
-  \bgroup\raggedright%
-  \bgroup\Huge\bfseries%
+\setkomafont{title}{\Huge\bfseries}%
+\setkomafont{subtitle}{\Large}%
+\setkomafont{author}{\large\itshape}%
+\setkomafont{date}{\large}%
+\newkomafont{matrikelnr}{\ttfamily}%
+
+\renewcommand*{\@maketitle}{%
+\global\@topnum=\z@
+\setparsizes{\z@}{\z@}{\z@\@plus 1fil}\par@updaterelative
+\ifx\@titlehead\@empty \else
+  \begin{minipage}[t]{\textwidth}
+    \usekomafont{titlehead}{\@titlehead\par}%
+  \end{minipage}\par
+\fi
+\null
+\vskip 2em%
+\ifx\@subject\@empty \else
+  {\usekomafont{subject}{\@subject \par}}%
+  \vskip 1.5em
+\fi
+{\usekomafont{title}{\huge \@title \par}}%
+\vskip .5em
+  {\ifx\@subtitle\@empty\else\usekomafont{subtitle}\@subtitle\par\fi}%
+\vskip .5em
+\noindent\vrule height 1.5pt width \textwidth%
+\vskip .75em plus .25em minus .25em%
+  {%
+    \usekomafont{author}{%
+      \lineskip .5em%
+      \begin{tabular}[t]{@{}l}
+        \@author
+      \end{tabular}\par
+    }%
+  }%
+\vskip 1em%
+  {\usekomafont{date}{\@date \par}}%
+\vskip \z@ \@plus 1em
+  {\usekomafont{publishers}{\@publishers \par}}%
+\ifx\@dedication\@empty \else
+  \vskip 2em
+    {\usekomafont{dedication}{\@dedication \par}}%
+\fi
+\par
+\vskip 2em
 }%
-% after title
-\posttitle{%
-  \egroup%
-  \newline%
-  \ifthenelse{\equal{\@subtitle}{}}{}{\large\@subtitle\newline}%
-  \egroup%
-  \noindent\vrule height 1.5pt width \textwidth%
-  \vskip .75em plus .25em minus .25em%
-}%
-% before author
-\preauthor{
-  \bgroup\raggedright%
-  \itshape%
-}%
-% after author
-\postauthor{%
-  \egroup%
-  \noindent\authormatrikelnrspacing\@matrikelnr%
-  \newline%
-}%
-% before date
-\predate{
-  \bgroup\raggedright%
-}%
-% after date
-\postdate{
-  \egroup%
+
+%%% MATRIKELNR
+\NewDocumentCommand{\matrikelnr}{ m }{%
+  (\bgroup\usekomafont{matrikelnr}{#1}\egroup)%
 }%
 
 %%% PAGESTYLE
-\pagestyle{fancy}
-\fancyhf{}
-\fancyhead[L]{\nouppercase{\leftmark}}
-\fancyhead[R]{\@author\ \@matrikelnr}
-\renewcommand{\headrulewidth}{0.2pt}
-\fancyfoot[C]{\thepage}
-\renewcommand{\footrulewidth}{0.2pt}
-\renewcommand{\footruleskip}{1em}
-\renewcommand{\subsectionmark}[1]{\markright{\thesubsection\ #1}}
+\KOMAoptions{%
+  automark,
+  headsepline
+}
+\clearpairofpagestyles%
+% header
+\ihead{\@author}%
+\ohead{\leftmark}%
+% footer
+\ofoot{\pagemark}
 
-%%% ITEMIZE STYLE
-\renewcommand\labelitemi{$\vcenter{\hbox{\small$\bullet$}}$}
+\RenewExpandableDocumentCommand{\pagemark}{}{%
+  \bgroup\usekomafont{pagenumber}\thepage\egroup%
+}
+\addtokomafont{pageheadfoot}{\upshape}
+
+% use header style
+\pagestyle{scrheadings}
+
+%\pagestyle{fancy}
+%\fancyhf{}
+%\fancyhead[L]{\nouppercase{\leftmark}}
+%\fancyhead[R]{\@author\ \@matrikelnr}
+%\renewcommand{\headrulewidth}{0.2pt}
+%\fancyfoot[C]{\thepage}
+%\renewcommand{\footrulewidth}{0.2pt}
+%\renewcommand{\footruleskip}{1em}
+%\renewcommand{\subsectionmark}[1]{\markright{\thesubsection\ #1}}
 
 %%% ENUMITEM
 % tabitemize
@@ -200,29 +222,32 @@
 
 %%% TABLE HEADER
 % set table header to bold
-\renewcommand\theadfont{\bfseries}
+\renewcommand{\theadfont}{\bfseries}
 \renewcommand{\theadalign}{cl}
 \renewcommand{\cellalign}{tl}
 
 %%% SIUNIX
 \sisetup{group-separator={\ }}
 
+%%% LISTINGS
+\lstset{
+  basicstyle=\ttfamily
+}
+
 %%% NEW COMMANDS
 % math set
 \DeclarePairedDelimiter\mset{\lbrace}{\rbrace}%
-\makeatletter
 \DeclareRobustCommand{\msetmid}{\@ifstar{\@msetmid}{\@@msetmid}}%
 \newcommand{\@msetmid}[2]{\ensuremath{\mset*{\, #1 \mathrel{\big|} #2 \,}}}%
 \newcommand{\@@msetmid}[2]{\ensuremath{\mset{\, #1 \mid #2 \,}}}%
-\makeatother
 
 % math tuple
 \DeclarePairedDelimiter\mtuple{\langle}{\rangle}%
 
 % logical true, false and xor
-\newcommand{\ltrue}{\ensuremath{\top}}%
-\newcommand{\lfalse}{\ensuremath{\bot}}%
-\newcommand{\lxor}{\ensuremath{\otimes}}%
+\NewDocumentCommand{\ltrue}{}{\ensuremath{\top}}%
+\NewDocumentCommand{\lfalse}{}{\ensuremath{\bot}}%
+\NewDocumentCommand{\lxor}{}{\ensuremath{\otimes}}%
 
 % abs and norm
 \DeclarePairedDelimiter\abs{\lvert}{\rvert}%
@@ -238,11 +263,28 @@
 % definedas
 \DeclareMathOperator{\definedas}{\ensuremath{\coloneqq}}%
 
+% intervals
+\NewDocumentCommand{\interval}{ m m m }{%
+  #1#2#3%
+}
+\NewDocumentCommand{\intervaloo}{ m }{%
+  \interval{\left(}{#1}{\right)}%
+}
+\NewDocumentCommand{\intervaloc}{ m }{%
+  \interval{\left(}{#1}{\right]}%
+}
+\NewDocumentCommand{\intervalco}{ m }{%
+\interval{\left[}{#1}{\right)}%
+}
+\NewDocumentCommand{\intervalcc}{ m }{%
+\interval{\left[}{#1}{\right]}%
+}
+
 %%% CONDITIONS
 \newenvironment{conditions}[1][\dots]{%
 \renewcommand{\arraystretch}{1.25}\par\noindent%
 \setlength\tabcolsep{1.5pt}%
-\newcommand{\sep}{#1}%
+\NewDocumentCommand{\sep}{}{#1}%
 \tabularx{\linewidth}{>{\(}r<{\)}>{\(}c<{\)}Z}%
 }{%
 \endtabularx\par\vspace{\belowdisplayskip}
@@ -275,19 +317,19 @@
 }
 
 % exercise title
-\newcommand{\printexercisetitle}{\formatexercisetitle}%
-\newcommand{\formatexercisetitle}{\exercisetitle}%
+\NewDocumentCommand{\formatexercisetitle}{}{\exercisetitle}%
+\NewDocumentCommand{\printexercisetitle}{}{\formatexercisetitle}%
 
 % exercise subtitle
-\newcommand{\formatexercisesubtitle}{:\ (\exercisesubtitle)}%
-\newcommand{\printexercisesubtitle}{\ifthenelse{\equal{\exercisesubtitle}{}}{}{\formatexercisesubtitle}}%
+\NewDocumentCommand{\formatexercisesubtitle}{}{:\ (\exercisesubtitle)}%
+\NewDocumentCommand{\printexercisesubtitle}{}{\ifthenelse{\equal{\exercisesubtitle}{}}{}{\formatexercisesubtitle}}%
 
 % exercise counter
-\newcommand{\formatexercisecounter}{\ \theexercisecounter}%
-\newcommand{\printexercisecounter}{\formatexercisecounter}%
+\NewDocumentCommand{\formatexercisecounter}{}{\ \theexercisecounter}%
+\NewDocumentCommand{\printexercisecounter}{}{\formatexercisecounter}%
 
 % exercise points
-\newcommand{\formatexercisepoints}{%
+\NewDocumentCommand{\formatexercisepoints}{}{%
   \ %
   \bgroup\mdseries\itshape%
   [%
@@ -300,43 +342,45 @@
   ]%
   \egroup%
 }
-\newcommand{\printexercisepoints}{%
+\NewDocumentCommand{\printexercisepoints}{}{%
   \ifshowexercisepoints
     \formatexercisepoints
   \fi
 }
 
 %environment
-\newenvironment{exercise}[1][]{%
+\NewDocumentEnvironment{exercise}{ O{} }{%
   \pgfkeys{/exercise, default, #1}%
   \refstepcounter{exercisecounter}%
+  \stepcounter{subsection}%
   \vskip\bigskipamount\noindent%
-  \bgroup\bfseries\large%
-  \exercisetitle \printexercisecounter \printexercisesubtitle \printexercisepoints%
+  \bgroup%
+  \bgroup\usekomafont{disposition}\usekomafont{subsection}\exercisetitle\printexercisecounter\egroup \printexercisesubtitle\printexercisepoints%
   \egroup%
   \vskip\medskipamount\noindent%
+  \addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}\exercisetitle\ \expanded{\theexercisecounter}}%
   \label{exe:\arabic{exercisecounter}}%
 }{}
 
 % solution title
-\newcommand{\formatsolutiontitle}{\solutiontitle}%
-\newcommand{\printsolutiontitle}{\formatsolutiontitle}%
+\NewDocumentCommand{\formatsolutiontitle}{}{\solutiontitle}%
+\NewDocumentCommand{\printsolutiontitle}{}{\formatsolutiontitle}%
 
 % solution counter
-\newcommand{\formatsolutioncounter}{\ \thesolutioncounter}%
-\newcommand{\printsolutioncounter}{\formatsolutioncounter}%
+\NewDocumentCommand{\formatsolutioncounter}{}{\ \thesolutioncounter}%
+\NewDocumentCommand{\printsolutioncounter}{}{\formatsolutioncounter}%
 
 % environment
-\newenvironment{solution}[1][]{%
-  \pgfkeys{/exercise/solution, #1}%
+\NewDocumentEnvironment{solution}{ O{} }{%
+  \pgfkeys{/exercise/solution,#1}%
   \refstepcounter{solutioncounter}%
-  \vskip\medskipamount\noindent%
+  \stepcounter{subsubsection}%
+  \vskip\bigskipamount\noindent%
   \bgroup%
-  \bfseries\normalsize%
-  \printsolutiontitle \printsolutioncounter%
-  \egroup%
-  \vskip\smallskipamount\noindent%
-  \label{sol:\arabic{solutioncounter}}%
+  \bgroup\usekomafont{disposition}\usekomafont{subsubsection}\printsolutiontitle\printsolutioncounter\egroup%
+  \egroup\vskip\medskipamount\noindent%
+  \addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}\expanded{\solutiontitle}\ \expanded{\thesolutioncounter}}%
+  \label{sol:\arabic{exercisecounter}-\arabic{solutioncounter}}%
 }{}
 
 %%% TCOLORBOX


### PR DESCRIPTION
- remove `parskip` package
- remove `titling` package
- remove `fancyhdr` package
- the template now expects a document class from the KOMAscript universe
- the Matrikel-Number now has to be supplied inside the author field
- the `geometry` package is no longer supplied with the `a4paper` key
- the margins have been changed to 2 cm horizontal and 3 cm vertical
- migrate all commands to use the newer `\NewDocumentCommand` functionality
- migrate all environments to use the newer `\NewDocumentEnvironment` functionality
- add `\intervaloo`, `\intervaloc`, `\intervalco`, `\intervalcc`
- the `exercise` environment now _behaves_ like a `subsection`
- the `solution` environment now _behaves_ like a `subsubsection`
- the `exercise` and `solution` environment are now correctly shown in the TOC
- rename colors prefix from "my" to "tua"
